### PR TITLE
Added function to get the path of the Voicemeeter DLL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,20 @@
+const { dirname, join } = require('path');
+const Registry = require('winreg');
+const koffi = require('koffi');
+
+const getDllPath = () => {
+
+    const regKey = new Registry({
+        hive: Registry.HKLM,
+        key: "\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\VB:Voicemeeter {17359A74-1236-5467}"
+    });
+
+    // TODO: Add some sort of error handling for this promise?
+    return new Promise((resolve, reject) => {
+        regKey.values((error, items) => {
+            const uninstallerPath = items.find((item) => item.name === "UninstallString").value;
+            resolve(join(dirname(uninstallerPath), "VoicemeeterRemote64.dll"));
+        });
+    });
+
+}


### PR DESCRIPTION
Uses winreg module to find Voicemeeter's uninstall path, and from there you can get the path of the Voicemeeter Remote DLL.